### PR TITLE
Fix Event<T>::operator() rvalue behavior with multiple handlers

### DIFF
--- a/Source/Primitives/Event.h
+++ b/Source/Primitives/Event.h
@@ -96,9 +96,19 @@ namespace vl
 		template<typename... TArgs2>
 		void operator()(TArgs2&& ...args)const
 		{
-			for(vint i = 0; i < handlers.Count(); i++)
+			auto count = handlers.Count();
+			if (count == 0) return;
+
+			if (count == 1)
 			{
-				handlers[i]->function(std::forward<TArgs2&&>(args)...);
+				handlers[0]->function(std::forward<TArgs2>(args)...);
+			}
+			else
+			{
+				for (vint i = 0; i < count; i++)
+				{
+					handlers[i]->function(args...);
+				}
 			}
 		}
 	};

--- a/Test/Source/TestFunction.cpp
+++ b/Test/Source/TestFunction.cpp
@@ -241,6 +241,28 @@ TEST_FILE
 			TEST_ASSERT(h2->IsAttached() == false);
 		});
 
+
+		TEST_CASE(L"Test Event<T> with rvalue arguments")
+		{
+			WString original = L"vczh";
+			WString h1Arg;
+			WString h2Arg;
+			Event<void(WString)> e;
+
+			e.Add([&](WString value)
+			{
+				h1Arg = value;
+			});
+			e.Add([&](WString value)
+			{
+				h2Arg = value;
+			});
+
+			e(WString::CopyFrom(original.Buffer(), original.Length()));
+
+			TEST_ASSERT(h1Arg == original);
+			TEST_ASSERT(h2Arg == original);
+		});
 		TEST_CASE(L"Test Event<T> with member functions")
 		{
 			EhObj o;


### PR DESCRIPTION
### Motivation

- Calling `Event<T>::operator()` with an rvalue would `std::forward` the same argument into every handler, causing the first handler to move-from the value and subsequent handlers to receive an empty/moved-from argument.
- A reproduction is adding an `Event<void(WString)>` with two handlers in the event unit tests and invoking it with an rvalue `WString`, where the second handler would observe an empty string.

### Description

- Changed `Event<void(TArgs...)>::operator()` in `Source/Primitives/Event.h` to check `handlers.Count()` and return immediately if zero, use perfect forwarding only when there is exactly one handler, and call handlers with plain `args...` when there are multiple handlers to avoid moving the same rvalue multiple times.
- Added a regression test `Test Event<T> with rvalue arguments` in `Test/Source/TestFunction.cpp` that constructs an `Event<void(WString)>` with two handlers and asserts both handlers receive the original `WString` when the event is invoked with an rvalue.
- Updated only `Source/Primitives/Event.h` and `Test/Source/TestFunction.cpp` to implement the fix and the test.

### Testing

- Built the test suite on Linux using `cd Test/Linux && ../../.github/Ubuntu/build.sh` and the build completed successfully.
- Ran the unit tests with `cd Test/Linux && ./Bin/UnitTest /C` and all test files and test cases passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a02017d48332a79face72ffa0ad3)